### PR TITLE
Require two datapoints for MasterBlockNumberComparisonAlarms

### DIFF
--- a/devops/replica_cluster.yaml
+++ b/devops/replica_cluster.yaml
@@ -2242,6 +2242,7 @@ Resources:
       AlarmDescription: "Alarms when the block number is missing"
       ComparisonOperator: "GreaterThanThreshold"
       EvaluationPeriods: 2
+      DatapointsToAlarm: 2
       Metrics:
         - Id: remote
           MetricStat:
@@ -2288,6 +2289,7 @@ Resources:
       AlarmDescription: "Alarms when the furthest behind master is too far behind other nodes"
       ComparisonOperator: "GreaterThanThreshold"
       EvaluationPeriods: 2
+      DatapointsToAlarm: 2
       Metrics:
         - Id: remote
           MetricStat:


### PR DESCRIPTION
Ropsten has been seeing a lot of reorgs lately. When this happens,
we'll often process 60+ blocks in a few seconds, but that means the
min(blockNumber) is significantly behind the max(blockNumber), which
triggers the MasterMinBlockNumberComparisonAlarm even though the
reorg is being handled gracefully. For larger reorgs, this can also
trigger the MasterBlockNumberComparisonAlarm.

By setting the DataPointsToAlarm to 2/2, we'll get alerts if we have
any masters that are genuinely running behind, but we won't get
woken up in the middle of the night just because a >20 block
reorg occurred.